### PR TITLE
fix(integration-common): Update integration-rest dependency version t…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -284,7 +284,7 @@ artifactory {
 }
 
 dependencies {
-    implementation "com.synopsys.integration:integration-rest:10.3.3"
+    implementation "com.synopsys.integration:integration-rest:10.3.6"
     implementation 'com.synopsys.integration:hub-imageinspector-lib:14.1.3'
     implementation 'ch.qos.logback:logback-classic:1.2.11'
 

--- a/build.gradle
+++ b/build.gradle
@@ -285,7 +285,7 @@ artifactory {
 
 dependencies {
     implementation "com.synopsys.integration:integration-rest:10.3.6"
-    implementation 'com.synopsys.integration:hub-imageinspector-lib:14.1.3'
+    implementation 'com.synopsys.integration:hub-imageinspector-lib:14.1.4'
     implementation 'ch.qos.logback:logback-classic:1.2.11'
 
     implementation "com.github.docker-java:docker-java-core:${dockerJavaVersion}"


### PR DESCRIPTION
**JIRA Bug:**
[IDETECT-3588](https://jira-sig.internal.synopsys.com/browse/IDETECT-3588)

**Description:**
`integration-common` is a transitive dependency of `detect-docker-inspector` (used by the integration-rest library) and to ensure detect-docker-inspector uses the latest version of `integration-common`, we update the integration-rest version to the latest release version i.e. `10.3.6` and the hub-imageinspector-lib version to its latest version i.e. `14.1.4`
