### PR TITLE
Update test endpoint for Detect script's download

### DIFF
--- a/src/test/java/com/blackduck/integration/blackduck/dockerinspector/endtoend/CalledFromDetectTest.java
+++ b/src/test/java/com/blackduck/integration/blackduck/dockerinspector/endtoend/CalledFromDetectTest.java
@@ -40,7 +40,7 @@ public class CalledFromDetectTest {
     @Test
     public void test() throws IOException, InterruptedException, IntegrationException {
 
-        String cmdGetDetectScriptString = String.format("curl --insecure -s https://detect.synopsys.com/detect%d.sh", DETECT_MAJOR_VERSION);
+        String cmdGetDetectScriptString = String.format("curl --insecure -s https://detect.blackduck.com/detect%d.sh", DETECT_MAJOR_VERSION);
         String detectScriptString = TestUtils.execCmd(executionDir, cmdGetDetectScriptString, ONE_MINUTE_IN_MS, true, null);
         File detectScriptFile = File.createTempFile("latestDetect", ".sh");
         detectScriptFile.setExecutable(true);


### PR DESCRIPTION
Now that the domain is active, update test endpoint to use "detect.blackduck.com" for downloading Detect scripts.

IDETECT-4520