### PR TITLE
Update signJar Gradle task to use the new Windows jar signing client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ task signJar() {
     finalizedBy 'verifyJar'
     doLast {
         exec {
-            commandLine 'jarsigner', '-tsa', 'http://rfc3161timestamp.globalsign.com/advanced', '-storetype', 'pkcs12', '-storepass', "${jarSigningKeystorePassword}", '-keystore', "${jarSigningKeystorePath}", "${createArtifactName()}", "${jarSigningCertificateAlias}"
+            commandLine 'signing-client', '--username', "${System.getenv('SIGNING_USER')}", '--password', "env:SIGNING_TOKEN", '--server', "${System.getenv('SIGNING_SERVER')}", '--port', '8000', '--signer', 'jarsigner', '--output', "${createArtifactName()}", "${createArtifactName()}"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ plugins {
 project.ext.inspectorImageFamily = "blackduck-imageinspector"
 project.ext.inspectorImageVersion = "6.0.1"
 
-version = '11.0.2-SNAPSHOT'
+version = '11.1.0-SNAPSHOT'
 
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'


### PR DESCRIPTION
This PR is identical to one made for detect: https://github.com/blackducksoftware/detect/pull/1305/files

A test build of this is currently in progress.