### PR TITLE
Bump up libraries to eliminate exploitable vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         javaTargetCompatibility = 8
         javaSourceCompatibility = 8
     }
-    ext['logback.version'] = '1.2.4-groovyless'
+    ext['logback.version'] = '1.2.13'
     ext['json-path.version'] = '2.10.0'
     apply from: "https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle", to: buildscript
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-cgp-version.gradle'
@@ -94,8 +94,8 @@ configurations {
             // Force json-path upgrade to fix known vulnerability
             force 'com.jayway.jsonpath:json-path:2.10.0'
             // Force logback upgrade to fix known vulnerability
-            force 'ch.qos.logback:logback-classic:1.2.4-groovyless'
-            force 'ch.qos.logback:logback-core:1.2.4-groovyless'
+            force 'ch.qos.logback:logback-classic:1.2.13'
+            force 'ch.qos.logback:logback-core:1.2.13'
         }
         // Bouncy Castle: docker-java pulls jdk15on:1.64, but from 1.71+ BC only publishes under jdk18on.
         // Use dependencySubstitution to swap artifact ID AND version in one step.
@@ -252,7 +252,7 @@ task createTestDockerfile(type: Dockerfile, dependsOn: createTestImagesDir) {
 }
 
 task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, createTestImagesDir]) {
-    commandLine "docker", "build", "--no-cache", "--tag", "blackducksoftware/centos_minus_vim_plus_bacula:1.0",        \
+    commandLine "docker", "build", "--platform", "linux/amd64", "--no-cache", "--tag", "blackducksoftware/centos_minus_vim_plus_bacula:1.0", \
                "src/test/resources"
 }
 
@@ -373,9 +373,9 @@ dependencyManagement {
 dependencies {
     implementation "com.blackduck.integration:integration-rest:11.1.2"
     implementation 'com.blackduck.integration:hub-imageinspector-lib:15.0.4'
-    implementation 'ch.qos.logback:logback-classic:1.2.4-groovyless'
+    implementation 'ch.qos.logback:logback-classic:1.2.13'
     constraints {
-        implementation('ch.qos.logback:logback-core:1.2.4-groovyless') {
+        implementation('ch.qos.logback:logback-core:1.2.13') {
             because 'previous version has a vulnerability'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -369,7 +369,7 @@ dependencyManagement {
 
 dependencies {
     implementation "com.blackduck.integration:integration-rest:11.1.4"
-    implementation 'com.blackduck.integration:hub-imageinspector-lib:15.0.4'
+    implementation 'com.blackduck.integration:hub-imageinspector-lib:15.0.5'
     implementation 'ch.qos.logback:logback-classic:1.2.13'
     constraints {
         implementation('ch.qos.logback:logback-core:1.2.13') {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ apply plugin: 'com.bmuschko.docker-remote-api'
 apply plugin: 'com.blackduck.integration.solution'
 
 final def externalRepoHost = "https://repo.blackduck.com"
-final def internalRepoHost = "https://artifactory.tools.duckutil.net"
+final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
 
 repositories {
     println "Checking if environment property SNPS_INTERNAL_ARTIFACTORY is configured: ${internalRepoHost}"

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,7 @@ buildscript {
         javaTargetCompatibility = 8
         javaSourceCompatibility = 8
     }
-    ext['logback.version'] = '1.5.32'
-    ext['slf4j.version'] = '2.0.13'
+    ext['logback.version'] = '1.2.4-groovyless'
     ext['json-path.version'] = '2.10.0'
     apply from: "https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle", to: buildscript
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-cgp-version.gradle'
@@ -95,11 +94,14 @@ configurations {
             // Force json-path upgrade to fix known vulnerability
             force 'com.jayway.jsonpath:json-path:2.10.0'
             // Force logback upgrade to fix known vulnerability
-            force 'ch.qos.logback:logback-classic:1.5.32'
-            force 'ch.qos.logback:logback-core:1.5.32'
-            // logback 1.5.x requires slf4j-api 2.x (LoggingEventAware); force it to match
-            force 'org.slf4j:slf4j-api:2.0.13'
-            force 'org.slf4j:jul-to-slf4j:2.0.13'
+            force 'ch.qos.logback:logback-classic:1.2.4-groovyless'
+            force 'ch.qos.logback:logback-core:1.2.4-groovyless'
+        }
+        // Bouncy Castle: docker-java pulls jdk15on:1.64, but from 1.71+ BC only publishes under jdk18on.
+        // Use dependencySubstitution to swap artifact ID AND version in one step.
+        resolutionStrategy.dependencySubstitution {
+            substitute module('org.bouncycastle:bcpkix-jdk15on') using module('org.bouncycastle:bcpkix-jdk18on:1.84')
+            substitute module('org.bouncycastle:bcprov-jdk15on') using module('org.bouncycastle:bcprov-jdk18on:1.84')
         }
     }
 }
@@ -371,9 +373,9 @@ dependencyManagement {
 dependencies {
     implementation "com.blackduck.integration:integration-rest:11.1.2"
     implementation 'com.blackduck.integration:hub-imageinspector-lib:15.0.4'
-    implementation 'ch.qos.logback:logback-classic:1.5.32'
+    implementation 'ch.qos.logback:logback-classic:1.2.4-groovyless'
     constraints {
-        implementation('ch.qos.logback:logback-core:1.5.32') {
+        implementation('ch.qos.logback:logback-core:1.2.4-groovyless') {
             because 'previous version has a vulnerability'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ configurations {
     // Force guava upgrade to fix known vulnerability (transitive from docker-java)
     all {
         resolutionStrategy {
-            force 'com.google.guava:guava:33.6.0-android'
+            force 'com.google.guava:guava:32.0.1-jre'
             // Force okio upgrade to fix known vulnerability (transitive from io.fabric8:kubernetes-client)
             force 'com.squareup.okio:okio:3.17.0'
             // Force json-path upgrade to fix known vulnerability

--- a/build.gradle
+++ b/build.gradle
@@ -368,7 +368,7 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation "com.blackduck.integration:integration-rest:11.1.2"
+    implementation "com.blackduck.integration:integration-rest:11.1.4"
     implementation 'com.blackduck.integration:hub-imageinspector-lib:15.0.4'
     implementation 'ch.qos.logback:logback-classic:1.2.13'
     constraints {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,9 @@ buildscript {
         javaTargetCompatibility = 8
         javaSourceCompatibility = 8
     }
-    ext['logback.version'] = '1.2.13'
+    ext['logback.version'] = '1.5.32'
+    ext['slf4j.version'] = '2.0.13'
+    ext['json-path.version'] = '2.10.0'
     apply from: "https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle", to: buildscript
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-cgp-version.gradle'
 
@@ -40,7 +42,7 @@ apply plugin: 'com.bmuschko.docker-remote-api'
 apply plugin: 'com.blackduck.integration.solution'
 
 final def externalRepoHost = "https://repo.blackduck.com"
-final def internalRepoHost = System.getenv('SNPS_INTERNAL_ARTIFACTORY')
+final def internalRepoHost = "https://artifactory.tools.duckutil.net"
 
 repositories {
     println "Checking if environment property SNPS_INTERNAL_ARTIFACTORY is configured: ${internalRepoHost}"
@@ -83,6 +85,23 @@ repositories {
 configurations {
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime
+
+    // Force guava upgrade to fix known vulnerability (transitive from docker-java)
+    all {
+        resolutionStrategy {
+            force 'com.google.guava:guava:33.6.0-android'
+            // Force okio upgrade to fix known vulnerability (transitive from io.fabric8:kubernetes-client)
+            force 'com.squareup.okio:okio:3.17.0'
+            // Force json-path upgrade to fix known vulnerability
+            force 'com.jayway.jsonpath:json-path:2.10.0'
+            // Force logback upgrade to fix known vulnerability
+            force 'ch.qos.logback:logback-classic:1.5.32'
+            force 'ch.qos.logback:logback-core:1.5.32'
+            // logback 1.5.x requires slf4j-api 2.x (LoggingEventAware); force it to match
+            force 'org.slf4j:slf4j-api:2.0.13'
+            force 'org.slf4j:jul-to-slf4j:2.0.13'
+        }
+    }
 }
 
 task writeVersionToPropertiesFile() {
@@ -342,12 +361,19 @@ artifactory {
     }
 }
 
+dependencyManagement {
+    dependencies {
+        // Override json-path managed by Spring Boot BOM to fix vulnerability
+        dependency 'com.jayway.jsonpath:json-path:2.10.0'
+    }
+}
+
 dependencies {
     implementation "com.blackduck.integration:integration-rest:11.1.2"
     implementation 'com.blackduck.integration:hub-imageinspector-lib:15.0.4'
-    implementation 'ch.qos.logback:logback-classic:1.2.13'
+    implementation 'ch.qos.logback:logback-classic:1.5.32'
     constraints {
-        implementation('ch.qos.logback:logback-core:1.2.13') {
+        implementation('ch.qos.logback:logback-core:1.5.32') {
             because 'previous version has a vulnerability'
         }
     }
@@ -366,6 +392,6 @@ dependencies {
     implementation group: 'org.freemarker', name: 'freemarker', version: '2.3.31'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'io.fabric8:kubernetes-client:3.1.8'
+    testImplementation 'io.fabric8:kubernetes-client:3.2.0'
     testImplementation 'io.fabric8:kubernetes-model:2.0.8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -93,9 +93,6 @@ configurations {
             force 'com.squareup.okio:okio:3.17.0'
             // Force json-path upgrade to fix known vulnerability
             force 'com.jayway.jsonpath:json-path:2.10.0'
-            // Force logback upgrade to fix known vulnerability
-            force 'ch.qos.logback:logback-classic:1.2.13'
-            force 'ch.qos.logback:logback-core:1.2.13'
         }
         // Bouncy Castle: docker-java pulls jdk15on:1.64, but from 1.71+ BC only publishes under jdk18on.
         // Use dependencySubstitution to swap artifact ID AND version in one step.
@@ -252,7 +249,7 @@ task createTestDockerfile(type: Dockerfile, dependsOn: createTestImagesDir) {
 }
 
 task buildTestDockerImage(type: Exec, dependsOn: [removeTestBaseImage, removeTestImage, createTestImagesDir]) {
-    commandLine "docker", "build", "--platform", "linux/amd64", "--no-cache", "--tag", "blackducksoftware/centos_minus_vim_plus_bacula:1.0", \
+    commandLine "docker", "build", "--no-cache", "--tag", "blackducksoftware/centos_minus_vim_plus_bacula:1.0",        \
                "src/test/resources"
 }
 


### PR DESCRIPTION
Libraries updated -
- json-path
- guava
- okio
- bouncycastle
- kubernetes-client

Notes on Logback 1.2.31 and [CVE-2026-1225](https://nvd.nist.gov/vuln/detail/CVE-2026-1225)

Upgrading to Logback 1.5+ (and Java 11) is scheduled for version 12.0. In the meantime, detect-docker-inspector is not vulnerable to CVE-2026-1225 for the following reasons:

- No Attack Surface: The project does not use a custom logback.xml file; Logback is managed entirely via Spring Boot auto-configuration. There is no local configuration file for an attacker to modify or exploit.
- High Barrier to Entry: Exploiting this vulnerability requires write access to the filesystem or the ability to inject JVM startup parameters (e.g., -Dlogback.configurationFile). If an attacker possesses this level of access, they could already execute far more critical attacks, such as replacing the JAR or injecting a Java agent.
- Low Impact: The CVE notes that even if a malicious class is successfully instantiated, it is "very likely to be discarded with no further ado," resulting in negligible impact on the system. 

In short, the existing security controls and Spring Boot configuration eliminate the practical risk posed by this CVE.